### PR TITLE
[WIP]omniauthでの登録時password登録の除外・omniauthで登録時のログイン機能の実装

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -15,12 +15,17 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # request.envにてHTTPリクエストの値を取得
     info = User.find_oauth(@omniauth)
     @user = info[:user]
-    if @user.persisted? 
+    if @user.persisted?
+      #persisted?:Active Record object がDB に保存済みかどうかを判定するメソッド
+      # @user情報がすでにDBに保存されていればその情報でログイン
       sign_in_and_redirect @user, event: :authentication
-      
-    else 
+      binding.pry
+    else
+      session[:sns_nickname] = info[:user].nickname
+      session[:sns_email] = info[:user].email
+      #providerから取得したnickname/email情報をsessionに渡す
       session[:sns_credentials_attributes] = info[:sns]
-      # binding.pry
+      #providerから取得したuid/provider情報をsessionに渡す
       redirect_to registration_signup_index_path
     end
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -19,7 +19,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       #persisted?:Active Record object がDB に保存済みかどうかを判定するメソッド
       # @user情報がすでにDBに保存されていればその情報でログイン
       sign_in_and_redirect @user, event: :authentication
-      binding.pry
     else
       session[:sns_nickname] = info[:user].nickname
       session[:sns_email] = info[:user].email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,7 @@ class User < ApplicationRecord
   #   取得してきたメールアドレスと同じメールアドレスがuserDBに保存されていれば、そのuser情報でログインし、omniauthで取得した情報も保存。
   #   取得してきたメールアドレスと同じメールアドレスがuserDBに保存されていなければ、
   #   omniauthで取得した,nameとemailをUserの新規インスタンスに渡してuidとproviderの情報をSNS_credeの新規インスタンスに渡して、新規登録画面へ
-  
+
   #   user = User.where(id: snscredential.user_id).first
   #   unless user.present?
   #     user = User.new(
@@ -83,7 +83,6 @@ class User < ApplicationRecord
     # 例　=>"google_oauth2"
     snscredential = SnsCredential.where(uid: uid, provider: provider).first
     # 取得してきた値と同じものがsns_credentialテーブルに保存されていれば、値を取得してsns_credentialに代入
-    binding.pry
     if snscredential.present?
       # sns_credentialテーブルから値が取得できているか？
       
@@ -91,7 +90,6 @@ class User < ApplicationRecord
       sns = snscredential
 
       #TODO:sns_credentialsDBに値が保存されていれば、userDBに値があるはず。。。sns_credentialsDBのみの登録がある場合は考えなくても良い？ user = with_sns_data(auth, snscredential)[:user]
-      binding.pry
     else
       user = without_sns_data(auth)[:user]
       sns = without_sns_data(auth)[:sns]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,39 +43,55 @@ class User < ApplicationRecord
           nickname: auth.info.name,
           email: auth.info.email
         )
-        # 新規userインスタンスにnicknameとemailを保存
+        # 新規userインスタンス作成しnicknameとemailを保存
         sns = SnsCredential.new(
           uid: auth.uid,
           provider: auth.provider
         )
-        # 新規sns_credentialインスタンスにuidとproviderを保存
+        # 新規sns_credentialインスタンス作成しuidとproviderを保存
       end
       return { user: user ,sns: sns}
     end
 
-   def self.with_sns_data(auth, snscredential)
-    user = User.where(id: snscredential.user_id).first
-    unless user.present?
-      user = User.new(
-        nickname: auth.info.name,
-        email: auth.info.email,
-      )
-    end
-    return {user: user}
-   end
+  #  def self.with_sns_data(auth, snscredential)
+  # callbackが呼ばれた際の処理逃れ
+  # omniauthで情報の取得
+  # 取得して来た情報と一致する情報がsns_credentialsDBに値が保存されいるのか？
+  # 分岐1
+  # 保存されていれば、そのままsns_credentialsDBのuser_idと一致するuser情報でログイン
+  # 保存されていなければ、
+  #   分岐2
+  #   取得してきたメールアドレスと同じメールアドレスがuserDBに保存されていれば、そのuser情報でログインし、omniauthで取得した情報も保存。
+  #   取得してきたメールアドレスと同じメールアドレスがuserDBに保存されていなければ、
+  #   omniauthで取得した,nameとemailをUserの新規インスタンスに渡してuidとproviderの情報をSNS_credeの新規インスタンスに渡して、新規登録画面へ
+  
+  #   user = User.where(id: snscredential.user_id).first
+  #   unless user.present?
+  #     user = User.new(
+  #       nickname: auth.info.name,
+  #       email: auth.info.email,
+  #     )
+  #   end
+  #   return {user: user}
+  #  end
 
    def self.find_oauth(auth)
     # request.envにてHTTPリクエストの値を取得し振り分け
     uid = auth.uid
-    # =>"103727882963069126588"
+    # 例　=>"103727882963069126588"
     provider = auth.provider
-    # =>"google_oauth2"
+    # 例　=>"google_oauth2"
     snscredential = SnsCredential.where(uid: uid, provider: provider).first
     # 取得してきた値と同じものがsns_credentialテーブルに保存されていれば、値を取得してsns_credentialに代入
+    binding.pry
     if snscredential.present?
       # sns_credentialテーブルから値が取得できているか？
-      user = with_sns_data(auth, snscredential)[:user]
+      
+      user = User.where(id: snscredential.user_id).first
       sns = snscredential
+
+      #TODO:sns_credentialsDBに値が保存されていれば、userDBに値があるはず。。。sns_credentialsDBのみの登録がある場合は考えなくても良い？ user = with_sns_data(auth, snscredential)[:user]
+      binding.pry
     else
       user = without_sns_data(auth)[:user]
       sns = without_sns_data(auth)[:sns]

--- a/app/views/signup/credit.html.haml
+++ b/app/views/signup/credit.html.haml
@@ -31,7 +31,7 @@
         %br/
         .single-main__container__form-group__input
           = f.fields_for :credit do |c|
-            = c.date_select  :expiration_date, { discard_day:true}, :class =>"single-main__container__form-group__input-form" ,start_year:Time.now.year-2000, end_year:Time.now.year-2000+10
+            = c.date_select  :expiration_date , { start_year:Time.now.year-2000, end_year:Time.now.year-2000+10,discard_day:true } , :class =>"single-main__container__form-group__input-form", discard_day:true
       .single-main__container__form-group
         = f.label :セキュリティコード
         %span.single-main__container__form-group__requier 必須

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -24,19 +24,19 @@
       .single-main__container__form-group
         = f.label :ニックネーム
         %span.single-main__container__form-group__requier 必須
-        = f.text_field :nickname, :class => "single-main__container__form-group__input-form", :placeholder => "例) メルカリ太郎", :type => "text", :value => "" 
+        = f.text_field :nickname, :class => "single-main__container__form-group__input-form", :placeholder => "例) メルカリ太郎", :type => "text", :value => "#{@user.nickname}"
       .single-main__container__form-group
         = f.label :email 
         %span.single-main__container__form-group__requier 必須
-        = f.email_field :email ,:class => "single-main__container__form-group__input-form", :placeholder => "PC.携帯どちらでも可", :type => "email", :value => "" 
+        = f.email_field :email ,:class => "single-main__container__form-group__input-form", :placeholder => "PC.携帯どちらでも可", :type => "email", :value => "#{@user.email}" 
       .single-main__container__form-group
         = f.label :パスワード
         %span.single-main__container__form-group__requier 必須
-        = f.text_field :password, :class => "single-main__container__form-group__input-form", :placeholder => "６文字以上", :type => "password", :value => "" 
+        = f.text_field :password, :class => "single-main__container__form-group__input-form", :placeholder => "６文字以上", :type => "password", :value => "#{@user.password}" 
       .single-main__container__form-group
         = f.label :パスワード（確認）
         %span.single-main__container__form-group__requier 必須
-        = f.text_field :password_confirmaiton, :class => "single-main__container__form-group__input-form", :placeholder => "６文字以上", :type => "password", :value => "" 
+        = f.text_field :password_confirmaiton, :class => "single-main__container__form-group__input-form", :placeholder => "６文字以上", :type => "password", :value => "#{@user.password}" 
       .single-main__container__form-group
         %h3 本人確認
         %p.single-main__container__form-group__text 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
@@ -59,9 +59,8 @@
         %span.single-main__container__form-group__requier 必須
         %br/
         .single-main__container__form-group__input
-          = f.date_select :birthday , {}, :class =>"single-main__container__form-group__input__herf", start_year:Time.now.year, end_year:1970   #,prompt:""
+          = f.date_select :birthday , {start_year:Time.now.year, end_year:1970}, :class =>"single-main__container__form-group__input__herf"   #,prompt:""
         -# #validate_birthday
-        -# Todo:date＿selectのclss指定
       .single-main__container__form-group
         %p.form-info-text ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
       .single-main__container__form-group


### PR DESCRIPTION

・omniauthでの新規登録時はnicknameとemail情報をそのまま保持。passwordは自動生成
・omniauthでのログイン機能を追加
・処理内容コメントアウトでベタがきしてます。

[omniauth-新規登録](https://gyazo.com/28d204ac76e31deb5a8053b58a1d0e5f)
[omniauth-新規登録（メールでの登録がある場合](https://gyazo.com/af62fb037d1239380db9ccaebcbdbbe1)
[omniauth-ログイン](https://gyazo.com/8ef217f0a89f4dd8fe1ebe8188975d0d)