### PR TITLE
商品編集時の画像のバリデーションを修正

### DIFF
--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -306,7 +306,7 @@ $(document).on('turbolinks:load', function () {
   }
 
   /**
-   * 商品画像のサムネイルの表示
+   * 商品画像設定時
    */
   $('#image').on('change', function () {
 
@@ -322,6 +322,7 @@ $(document).on('turbolinks:load', function () {
     if (file && permit_type.indexOf(file.type) == -1) {
       alert('この形式のファイルはアップロードできません');
       $('#image').val('');
+      $('#sell_image_exists').val(false);
       return
     }
 
@@ -332,9 +333,11 @@ $(document).on('turbolinks:load', function () {
     }
 
     var reader = new FileReader();
+    // 画像を読み込んだ時にサムネイルを表示する
     reader.onload = function () {
       //1つしか画像を表示させないため、表示されている画像があれば削除する
       $('.sell-upload-picture').remove();
+      $('#sell_image_exists').val(false);
 
       var html = `
       <li class="sell-upload-picture">
@@ -354,8 +357,9 @@ $(document).on('turbolinks:load', function () {
       $('.sell-dropbox__pictures').addClass('sell-dropbox__pictures--item1');
       $('.sell-dropbox-area').removeClass('sell-dropbox-area--item0');
       $('.sell-dropbox-area').addClass('sell-dropbox-area--item1');
+      $('#sell_image_exists').val(true);
     }
-
+    // 画像を読み込む
     reader.readAsDataURL(file);
   });
 
@@ -370,6 +374,7 @@ $(document).on('turbolinks:load', function () {
     $('.sell-dropbox-area').removeClass('sell-dropbox-area--item1');
     $('.sell-dropbox-area').addClass('sell-dropbox-area--item0');
     $('#image').val('');
+    $('#sell_image_exists').val(false);
   });
 
 });

--- a/app/assets/javascripts/sell.validate.js
+++ b/app/assets/javascripts/sell.validate.js
@@ -60,14 +60,84 @@ $(document).on('turbolinks:load', function () {
         rangelength: '1千万未満で金額設定してください'
       }
     },
-   
+
     errorPlacement: function(error, element){
       if (element.attr("name")=="item[image]"){
         error.appendTo($('#validation_image'));
       }else {
       error.insertAfter(element);
-      } 
-    }  
+      }
+    }
   });
 });
 
+
+$(document).on('turbolinks:load', function () {
+  $.validator.addMethod("boolCheck", function(value, element,origin){
+    return origin != value;
+  }, '商品画像は必須項目です。必ず一枚以上貼付してください。');
+
+  $('#selledititem').validate({
+    ignore: [],
+    errorClass: 'valid-err',
+    rules: {
+      "item[image_exists]": {
+        boolCheck: "false",
+      },
+      "item[name]": {
+        required: true
+      },
+      "item[description]": {
+        required: true
+      },
+      "item[category_id]": {
+        selectCheck: 0,
+        required: true
+      },
+      "category_root_id": {
+        selectCheck: 0
+      },
+      "category_child_id": {
+        selectCheck: 0
+      },
+      "category_grandchild_id": {
+        selectCheck: 0
+      },
+      "item[price]": {
+        required: true,
+        number: true,
+        rangelength: [1, 7]
+      },
+      "item[item_status]": {
+        selectCheck: 0
+      },
+      "item[shipping_charge]": {
+        selectCheck: 0
+      },
+      "item[delivery_type]": {
+        selectCheck: 0
+      },
+      "item[delivery_region]": {
+        selectCheck: 0
+      },
+      "item[delivery_days]": {
+        selectCheck: 0
+      }
+    },
+
+    messages: {
+      "item[price]": {
+        rangelength: '1千万未満で金額設定してください'
+      }
+    },
+
+    errorPlacement: function (error, element) {
+      if (element.attr("name") == "item[image_exists]") {
+        error.appendTo($('#validation_image'));
+      } else {
+        error.insertAfter(element);
+      }
+    }
+  });
+
+});

--- a/app/views/sell/_form.html.haml
+++ b/app/views/sell/_form.html.haml
@@ -1,13 +1,15 @@
 %h2.sell-container__head 商品の情報を入力
 - path = type == :edit ? "/sell/#{item.id}" : "/sell"
 - method = type == :edit ? :put : :post
-= form_for item , url: "#{path}", method: method, html: {id: :sellnewitem ,class: "sell-form"} do |f|
+- form_id = type == :edit ? :selledititem : :sellnewitem
+= form_for item , url: "#{path}", method: method, html: {id: form_id, class: "sell-form"} do |f|
   .sell-upload-box
     %h3.sell-upload-box__head
       出品画像
       %span.sell-form-require 必須
     %p.sell-upload-box__note 最大10枚までアップロードできます
     #validation_image
+    = f.hidden_field("image_exists", value: item.image.present?, id: "sell_image_exists")
     .sell-dropbox
       .sell-dropbox__picturebox
         .sell-dropbox__pictures{class: "sell-dropbox__pictures--item#{item.image.present? ? 1 : 0}"}


### PR DESCRIPTION
# 変更内容
出品した商品の画像のバリデーションを変更。
判定用に`<input type="hidden" name="item[image_exists]">`を追加。
値が`false`の時は、バリデーションエラーを表示するように設定

# 原因
編集画面表示時、登録済みの画像は`<input type="file" name="item[image]">`に情報がセットされないため、画像が登録されていてもバリデーションエラーとなってしまう。
