### PR TITLE
パンくずリストを実装07

### DIFF
--- a/app/views/logout/index.html.haml
+++ b/app/views/logout/index.html.haml
@@ -1,3 +1,4 @@
+-breadcrumb :mypage_logout_index
 = render 'devise/shared/header'
 %main.mypage-container
   = render 'mypages/sidemenu'

--- a/app/views/mypages/credit.html.haml
+++ b/app/views/mypages/credit.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :mypage_credit
 = render 'devise/shared/header'
 %main.mypage-container
   = render 'sidemenu'

--- a/app/views/mypages/deliver_address.html.haml
+++ b/app/views/mypages/deliver_address.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :mypage_deliver_address
 = render 'devise/shared/header'
 %main.mypage-container
   = render 'sidemenu'

--- a/app/views/mypages/email_password.html.haml
+++ b/app/views/mypages/email_password.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :mypage_email_password
 = render 'devise/shared/header'
 %main.mypage-container
   = render 'sidemenu'

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :mypage_profile
 = render 'devise/shared/header'
 %main.mypage-container
   = render 'sidemenu'

--- a/app/views/mypages/sms_confirmation.html.haml
+++ b/app/views/mypages/sms_confirmation.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :mypage_sms_confirmation
 = render 'devise/shared/header'
 %main.mypage-container
   = render 'sidemenu'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,6 +2,11 @@ crumb :root do
   link "メルカリ", root_path
 end
 
+crumb :item do |item|
+  link item.name, item_path
+  parent :root
+end
+
 crumb :category do
   link "カテゴリー一覧" # パスを指定
 end
@@ -20,9 +25,34 @@ crumb :mypage_identification do
   parent :mypage
 end
 
-crumb :item do |item|
-  link item.name, item_path
-  parent :root
+crumb :mypage_profile do
+  link "プロフィール", profile_mypages_path
+  parent :mypage
+end
+
+crumb :mypage_deliver_address do
+  link "発送元・お届け先住所変更", deliver_address_mypages_path
+  parent :mypage
+end
+
+crumb :mypage_credit do
+  link "支払い方法", credit_mypages_path
+  parent :mypage
+end
+
+crumb :mypage_email_password do
+  link "メール/パスワード", email_password_mypages_path
+  parent :mypage
+end
+
+crumb :mypage_sms_confirmation do
+  link "電話番号の確認", sms_confirmation_mypages_path
+  parent :mypage
+end
+
+crumb :mypage_logout_index do
+  link "ログアウト", logout_index_path
+  parent :mypage
 end
 
 # crumb :projects do


### PR DESCRIPTION
# What
マイページで不足していた箇所を追加で実装しました。
CSSはまだ当てていません。
・プロフィール
・住所変更
・支払い方法
・メール/パスワード
・電話番号の確認
・ログアウト