### PR TITLE
各修正

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,5 +1,6 @@
-document.addEventListener(
-  "DOMContentLoaded", e => {
+$(document).on('turbolinks:load', function () {
+// document.addEventListener(
+//   "DOMContentLoaded", e => {
     if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
       Payjp.setPublicKey("pk_test_9c583fc4c32d77c7a5f99703"); //ここに公開鍵を直書き
       let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
@@ -29,5 +30,5 @@ document.addEventListener(
       });
     }
   },
-  false
+  // false
 );

--- a/app/assets/javascripts/slide.js
+++ b/app/assets/javascripts/slide.js
@@ -1,4 +1,3 @@
-
 $(function(){
   setInterval(function(){
     $('#slide1').toggleClass("invisible");
@@ -6,10 +5,12 @@ $(function(){
   },3000);
 });
 
-$(function(){
-  $('button').click(function() {
-    $('#slide1').toggleClass("invisible");
-    $('#slide2').toggleClass("invisible");
+
+$(document).on('turbolinks:load', function () {
+  $(function(){
+    $('button').click(function() {
+      $('#slide1').toggleClass("invisible");
+      $('#slide2').toggleClass("invisible");
+    });
   });
 });
-

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -40,7 +40,7 @@ class MypagesController < ApplicationController
     if @user.update(id:current_user.id)
       redirect_to mypages_path, notice: '更新しました。'
     else
-      redirect_to mypages_path, notice: '更新失敗！！！'
+      redirect_to mypages_path, notice: '更新が失敗しました。'
     end
   end
 
@@ -50,7 +50,7 @@ class MypagesController < ApplicationController
     if @address.update(user_id: current_user.id)
       redirect_to mypages_path, notice: '更新しました。'
     else
-      redirect_to mypages_path, notice:'更新失敗！！！！'
+      redirect_to mypages_path, notice:'更新が失敗しました。'
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   validates :birthday, presence: true
   validates :tel, presence: true ,numericality: true ,length: {is:11}
   validates :email ,presence: true, uniqueness: true         
-  validates :password, presence: true, length: { minimum: 6 }, confirmation: true
+
 
 
   enum address_prefecture: {


### PR DESCRIPTION
# what
・pay.jp登録時のturbolinksによる画面二重遷移を修正
・topページスクロール画像のturbolinksによる画像変更ボタンの無効化を修正
・model validationが原因でユーザー情報が更新でき無かったので修正
# why
ユーザビリティ向上のため