### PR TITLE
Fix layout2

### DIFF
--- a/app/assets/stylesheets/mypages.scss
+++ b/app/assets/stylesheets/mypages.scss
@@ -15,6 +15,7 @@
   width: 700px;
   background-color: #f5f5f5;
   padding-bottom: 50px;
+
 }
 
 .mypage-navi {
@@ -30,6 +31,44 @@
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.delete__button {
+  color: #ea352d;
+  border: 1px solid #ea352d;
+  background: #fff;
+  float: right;
+  position:  relative;
+  top: -40px;
+  right: 100px;
+}
+
+.delete-card-head {
+  padding: 12px 4%;
+  border-bottom: 1px solid #f5f5f5;
+  text-align: center;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.delete-card-inner {
+  margin-left: 40px;
+  border-top: 1px solid #f5f5f5;
+  padding: 40px;
+}
+
+.delete-card-title {
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 14px;
+}
+
+.delete-card-number {
+  margin-top: 8px;
+}
+
+.delete-card-time {
+  margin: 8px 0 0;
 }
 
 .navi-item {

--- a/app/assets/stylesheets/sell.scss
+++ b/app/assets/stylesheets/sell.scss
@@ -465,3 +465,41 @@
     color: #fff;
   }
 }
+
+.modal-inner {
+  background-color: #fff;
+  div {
+    .modal-head {
+      padding: 12px 4%;
+      border-bottom: 1px solid #f5f5f5;
+      text-align: center;
+      font-size: 18px;
+      font-weight: bold;
+
+    } 
+    .sell-modal-body {
+      text-align: center;
+      #red-link {
+        display: block;
+        width: 343px;
+        line-height: 48px;
+        font-size: 14px;
+        border: 1px solid transparent;
+        -webkit-transition: all ease-out .3s;
+        transition: all ease-out .3s;
+        text-align: center;
+        margin: 0 auto;
+        margin-bottom: 20px;
+        background: #ea352d;
+        border: 1px solid #ea352d;
+        color: #fff;
+        margin-top: 20px;
+      }
+      #blue-link {
+        color: rgb(0, 149, 238);
+      }
+    } 
+  }   
+}
+  
+        

--- a/app/controllers/credit_controller.rb
+++ b/app/controllers/credit_controller.rb
@@ -61,15 +61,15 @@ class CreditController < ApplicationController
       redirect_to action: "confirmation", id: current_user.id
   end
 
-  def show
-    card = Credit.where(user_id: current_user.id).first
-    if card.present?
-      customer = Payjp::Customer.retrieve(card.customer_id)
-      @default_card_information = customer.cards.retrieve(card.card_id)
-    else
-      redirect_to action: "confirmation", id: current_user.id
-    end
-  end
+  #def show
+    #card = Credit.where(user_id: current_user.id).first
+    #if card.present?
+      #customer = Payjp::Customer.retrieve(card.customer_id)
+      #@default_card_information = customer.cards.retrieve(card.card_id)
+    #else
+      #redirect_to action: "confirmation", id: current_user.id
+    #end
+  #end
 
   def confirmation
     #card = Credit.where(user_id: current_user.id).first

--- a/app/views/buy/purchase.html.haml
+++ b/app/views/buy/purchase.html.haml
@@ -4,6 +4,6 @@
     .sell-modal-body
       出品者の発送通知をお待ちください。
       %p.text-center
-        = link_to 'マイページへ', mypages_path, class: 'btn-default.btn-red'
+        = link_to 'マイページへ', mypages_path, class: 'btn-default.btn-red', id: 'red-link'
         -# mypages#indexへ飛ぶようにした。
         -# 本来なら「シェアする」、「取引画面へ」というリンク。

--- a/app/views/mypages/credit.html.haml
+++ b/app/views/mypages/credit.html.haml
@@ -7,8 +7,8 @@
       %h2.delete-card-head 支払い方法
 
       .mypage-content__box__form-froup.delete-card-inner
-        %p.delete-card-title クレジットカード一覧
         - if @credit.present?
+          %p.delete-card-title クレジットカード一覧
           = image_tag 'visa.svg', alt: 'visa', class: 'visa'
           .delete-card-number
           = "**** **** **** " + @default_card_information.last4

--- a/app/views/mypages/credit.html.haml
+++ b/app/views/mypages/credit.html.haml
@@ -4,15 +4,18 @@
   = render 'sidemenu'
   .mypage-content
     .mypage-content__box
-      %h2.mypage-content__box__header 支払い方法
+      %h2.delete-card-head 支払い方法
 
-      .mypage-content__box__form-froup
-        %p.text-center クレジットカード一覧
+      .mypage-content__box__form-froup.delete-card-inner
+        %p.delete-card-title クレジットカード一覧
         - if @credit.present?
+          = image_tag 'visa.svg', alt: 'visa', class: 'visa'
+          .delete-card-number
           = "**** **** **** " + @default_card_information.last4
-          - exp_month = @default_card_information.exp_month.to_s
-          - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
-          = exp_month + " / " + exp_year
+          .delete-card-time
+            - exp_month = @default_card_information.exp_month.to_s
+            - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+            = exp_month + " / " + exp_year
           = form_tag(delete_credit_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
             %input{ type: "hidden", name: "card_id", value: "" }
             %button.delete__button 削除する

--- a/app/views/sell/completed.html.haml
+++ b/app/views/sell/completed.html.haml
@@ -4,4 +4,4 @@
     .sell-modal-body
       購入者の受取確認と評価をしばらくお待ちください
       %p.text-center
-        = link_to 'マイページへ', mypages_path, class: 'btn-default.btn-red'
+        = link_to 'マイページへ', mypages_path, class: 'btn-default.btn-red', id: 'red-link'

--- a/app/views/sell/create.html.haml
+++ b/app/views/sell/create.html.haml
@@ -4,7 +4,7 @@
     .sell-modal-body
       あなたが出品した商品は「出品した商品一覧」からいつでも見ることができます。
       %p.text-center
-        = link_to '続けて出品する', sell_index_path, class: 'btn-default.btn-red'
+        = link_to '続けて出品する', sell_index_path, class: 'btn-default.btn-red', id: 'red-link'
         / sell#newへ飛ぶ。
       %p.text-center
-        = link_to '商品ページへ行ってシェアする', item_path(@item)
+        = link_to '商品ページへ行ってシェアする', item_path(@item), id: 'blue-link'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,14 +55,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :credit, only: [:create, :show] do
+  resources :credit, only: [:create] do
     collection do
       post 'delete', to: 'credit#delete'
-      post 'show'
       get 'edit'
     end
     member do
-      get 'show'
       get 'confirmation'
     end
   end


### PR DESCRIPTION
What
・クレジットカード情報を表示するページのレイアウトを修正しました
・購入後や出品後に表示されるページのレイアウトを修正しました
・使用しなくなったcreditのshowページのルーティングを削除しました

Why
・レイアウトに統一感を持たせるため
・セキュリティ上使用しないページにアクセスできることは避けたいため

スクリーンショット
https://gyazo.com/84191389daa0e21cd733636fef5404f7
https://gyazo.com/8d93ae481f7e690b3d4a8fafaa530ca8
https://gyazo.com/cea6984d903193c39116406a726f4df0